### PR TITLE
[OF] Dependency update now passes more information to the next layer

### DIFF
--- a/.github/workflows/L1_PushToPublic.yml
+++ b/.github/workflows/L1_PushToPublic.yml
@@ -44,9 +44,15 @@ jobs:
     needs: build-and-push
     runs-on: ubuntu-latest
     steps:
-    - name: Trigger main workflow in L2.Common
-      uses: peter-evans/repository-dispatch@v3
-      with:
-        token: ${{ secrets.PAT_TOKEN }} 
-        repository: Biognosys/SF.Common
-        event-type: L1-dependency-update
+      - name: Trigger main workflow in L2.Common
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PAT_TOKEN }} 
+          repository: Biognosys/SF.Common
+          event-type: L1-dependency-update
+          client-payload: |
+            {
+              "source_repo": "${{ github.repository }}",
+              "source_tag": "${{ github.event.inputs.tag || 'latest' }}",
+              "source_commit": "${{ github.sha }}"
+            }


### PR DESCRIPTION
Minor change.
The API call to L2 now includes some more information:

- Repo name
- Image tag
- Commit hash

This info will be shown in the automatic PR created for the dependency update.