### PR TITLE
SF-1914 feat(licensing): Improve license activation docs and add hear…

### DIFF
--- a/src/CleanArchitecture/Infrastructure/TGF.CA.Infrastructure.Licensing/Slascone/Contracts/ILicensingService.cs
+++ b/src/CleanArchitecture/Infrastructure/TGF.CA.Infrastructure.Licensing/Slascone/Contracts/ILicensingService.cs
@@ -58,9 +58,23 @@ public interface ILicensingService {
     LicenseComplianceStatus ComplianceStatus { get; }
 
     /// <summary>
-    /// Activates a license for the current device using the provided license key.
+    /// Activates the software on the current device using the specified license key.
     /// </summary>
-    /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// <para>
+    /// Activation binds the license key to the unique hardware identity of the device, 
+    /// enabling compliance verification and the acquisition of floating license seats.
+    /// This process requires an active internet connection to communicate with the SLASCONE service.
+    /// </para>
+    /// <para>
+    /// <b>Note:</b> If the device is already activated, calling this method will overwrite 
+    /// existing activation data, effectively re-activating the device with the new license key.
+    /// </para>
+    /// </remarks>
+    /// <returns>A <see cref="Task"/> representing the asynchronous activation operation.</returns>
+    /// <exception cref="Exception">
+    /// Thrown if the license key is invalid, already in use, or if a network error occurs.
+    /// </exception>
     Task ActivateLicenseAsync();
 
     /// <summary>
@@ -84,6 +98,7 @@ public interface ILicensingService {
     /// Sends a heartbeat to the SLASCONE service to validate the license.
     /// Updates license information based on the server response.
     /// </summary>
+    /// <remarks>The method checks that the license key used for heartbeat (the one used for activation) is the same as the one in the secret file. If they are different, treat the heartbeat as failed and logs a warning. They should never be different so treat the heartbeat as failed, and log a warning because this will almost guarantee 2006 unknow device error on open floating session.</remarks>
     /// <returns>A task representing the asynchronous operation.</returns>
     Task AddHeartbeatAsync();
 

--- a/src/CleanArchitecture/Infrastructure/TGF.CA.Infrastructure.Licensing/Slascone/Services/LicensingService.cs
+++ b/src/CleanArchitecture/Infrastructure/TGF.CA.Infrastructure.Licensing/Slascone/Services/LicensingService.cs
@@ -111,13 +111,18 @@ internal sealed class LicensingService(
                 return;
             }
 
-            
-
             var licenseInfoDto = result.data;
             _tokenId = licenseInfoDto.Token_key;
             LicenseInfo = licenseInfoDto;
-            HeartbeatStatus = LicenseHeartbeatStatus.Success;
-            if(ActivationStatus != LicenseActivationStatus.Activated) // If heartbeat is successful, set activation status to activated. Only activeated devices add heartbeats successfully.
+
+            if(await GetLicenseKeyFromSecretFile() != licenseInfoDto.License_key) { // This is a safety check to make sure that the license key used for heartbeat (the one used for activation) is the same as the one in the secret file. They should never be different so treat the heartbeat as failed, and log a warning, because this will almost guarantee 2006 unknow device error on open floating session.
+                logger.LogWarning("[LICENSE] The license key used for heartbeat is different from the one in the secret file. This could indicate an issue with license activation or heartbeat.");
+                HeartbeatStatus = LicenseHeartbeatStatus.Failed;
+                return; 
+            }
+
+            HeartbeatStatus = LicenseHeartbeatStatus.Success;      
+            if (ActivationStatus != LicenseActivationStatus.Activated) // If heartbeat is successful, set activation status to activated. Only activeated devices add heartbeats successfully.
                 ActivationStatus = LicenseActivationStatus.Activated;
             LimitationMap = licensePrinter.PrintLicenseDetails(licenseInfoDto);
         }


### PR DESCRIPTION
…tbeat key check

Expanded XML docs for ActivateLicenseAsync and AddHeartbeatAsync to clarify activation behavior and error handling. Added a runtime check in LicensingService to ensure the license key used for heartbeat matches the secret file, logging a warning and failing the heartbeat if mismatched to prevent device errors. HeartbeatStatus is now only set to Success if the key check passes.